### PR TITLE
Remove libsamplerate dep.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,21 +18,5 @@ SOURCES += $(wildcard src/*.cpp)
 DISTRIBUTABLES += res
 DISTRIBUTABLES += $(wildcard LICENSE*)
 
-
-# Static libs
-libsamplerate := dep/lib/libsamplerate.a
-OBJECTS += $(libsamplerate)
-
-# Dependencies
-DEPS += $(libsamplerate)
-
-$(libsamplerate):
-	$(WGET) http://www.mega-nerd.com/SRC/libsamplerate-0.1.9.tar.gz
-	cd dep && $(UNTAR) ../libsamplerate-0.1.9.tar.gz
-	cd dep/libsamplerate-0.1.9 && $(CONFIGURE)
-	cd dep/libsamplerate-0.1.9/src && $(MAKE)
-	cd dep/libsamplerate-0.1.9/src && $(MAKE) install
-
-
 # Include the Rack plugin Makefile framework
 include $(RACK_DIR)/plugin.mk

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 RACK_DIR ?= ../..
 
 # FLAGS will be passed to both the C and C++ compiler
-FLAGS += -Idep/include
+#FLAGS += 
 #CFLAGS +=
 #CXXFLAGS +=
 


### PR DESCRIPTION
This fixes #20 and should allow @andrewbelt to build for the VCV Library . 

I added the built binaries to my fork.